### PR TITLE
[#8] Hotfix database misspelling

### DIFF
--- a/database/migrations/250220-rddb.migration.sql
+++ b/database/migrations/250220-rddb.migration.sql
@@ -5,7 +5,7 @@ USE `rddb`;
 -- Table: authentications
 CREATE TABLE `authentications` (
     `authentication_id` INT AUTO_INCREMENT PRIMARY KEY,
-    `identifer_email` VARBINARY(1000) NOT NULL,
+    `identifier_email` VARBINARY(1000) NOT NULL,
     `password` VARBINARY(1000) NOT NULL,
     `role` ENUM('ADMIN', 'STORE', 'CUSTOMER') NOT NULL,
     `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/database/seeders/250220-rddb.seeder.sql
+++ b/database/seeders/250220-rddb.seeder.sql
@@ -10,7 +10,7 @@ TRUNCATE TABLE authentications;
 
 SET FOREIGN_KEY_CHECKS = 1;
 
-INSERT INTO `authentications` (`identifer_email`, `password`, `role`) VALUES
+INSERT INTO `authentications` (`identifier_email`, `password`, `role`) VALUES
     (AES_ENCRYPT('admin@example.com', 'secret_key'), AES_ENCRYPT('password123', 'secret_key'), 'ADMIN'),
     (AES_ENCRYPT('store@example.com', 'secret_key'), AES_ENCRYPT('password123', 'secret_key'), 'STORE'),
     (AES_ENCRYPT('customer@example.com', 'secret_key'), AES_ENCRYPT('password123', 'secret_key'), 'CUSTOMER');


### PR DESCRIPTION
## About

 - Date: February 20th 2025
 - This pull request fix database misspelling
 - This pull request will closes #8 

## Changes Included

- Change `identifer` -> `identifier` in both [250220-rddb.migration.sql](https://github.com/qthiendev/Repair-Dash-System-BE/blob/hotfix/8_database_misspelling/database/migrations/250220-rddb.migration.sql) and [250220-rddb.seeder.sq](https://github.com/qthiendev/Repair-Dash-System-BE/blob/hotfix/8_database_misspelling/database/seeders/250220-rddb.seeder.sql)